### PR TITLE
fixes so "catkin_make" won't error out (otherwise complains about .h …

### DIFF
--- a/domains/integrator_chains/dynamaestro/CMakeLists.txt
+++ b/domains/integrator_chains/dynamaestro/CMakeLists.txt
@@ -21,6 +21,8 @@ if (CATKIN_ENV)
   find_package (catkin REQUIRED COMPONENTS roscpp tf integrator_chains_msgs)
 
   catkin_package ()
+  add_dependencies (log integrator_chains_msgs_generate_messages_cpp)
+  add_dependencies (dm integrator_chains_msgs_generate_messages_cpp)
   include_directories (include ${catkin_INCLUDE_DIRS})
   target_link_libraries (log ${catkin_LIBRARIES})
   target_link_libraries (dm ${catkin_LIBRARIES})


### PR DESCRIPTION
…files not existing)

adding "add_dependencies ()" to each target so that catkin_make will forcibly make the integrator_chains_msgs messages (.h files) before trying to compile dynamaestro; this is a problem in v0.0.1, so likely an issue in later versions too
