### PR TITLE
Find catkin before invoking catkin_package()

### DIFF
--- a/domains/dubins_traffic/dub_sim/CMakeLists.txt
+++ b/domains/dubins_traffic/dub_sim/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(dub_sim)
+
+find_package(catkin REQUIRED)
 catkin_package()
 
 install(DIRECTORY launch models urdf

--- a/domains/dubins_traffic/dubins_traffic_utils/CMakeLists.txt
+++ b/domains/dubins_traffic/dubins_traffic_utils/CMakeLists.txt
@@ -4,6 +4,7 @@ add_compile_options (-std=c++11)
 
 include_directories (include)
 
+find_package(catkin REQUIRED)
 find_package (Eigen3 REQUIRED)
 include_directories (${EIGEN3_INCLUDE_DIR})
 


### PR DESCRIPTION
Some fixes to the dubins traffic ROS packages' `CMakeLists.txt` files. I think you've been depending on other packages finding `catkin`, which `catkin_make` allows. With these fixes, you can also build with `catkin` (aka [catkin_tools](https://github.com/catkin/catkin_tools))

I'm not as confident about the `dubins_traffic_utils` change because there's some extra logic there.
